### PR TITLE
Update PAL-D/K mode

### DIFF
--- a/src/com/steeviebops/resources/CaptainJack/Modes.ini
+++ b/src/com/steeviebops/resources/CaptainJack/Modes.ini
@@ -169,21 +169,21 @@ vhf=vhf_eu
 
 [pal-d]
 alt=pal-k
-name=PAL-D/K (625 lines, 25 fps, 6.5 MHz FM audio)
+name=PAL-D/K (625 lines, 25 fps/50 Hz, 6.5 MHz FM audio)
 lines=625
 modulation=vsb
 sr=16000000
 colour=1
 audio=1
-nicam=0
-a2stereo=0
+nicam=1
+a2stereo=1
 teletext=1
 wss=1
 vits=1
 acp=1
 scrambling=1
-uhf=0
-vhf=0
+uhf=uhf_eu
+vhf=vhf_cn
 
 [pal-fm]
 name=PAL-FM (625 lines, 25 fps/50 Hz, 7.02/7.20 MHz FM stereo audio)
@@ -742,6 +742,36 @@ F9=190300000
 F10=199700000
 F11=203450000
 F12=212850000
+
+[vhf_cn]
+region=China
+C1=49750000
+C2=57750000
+C3=65750000
+C4=77250000
+; Channels 5 overlap with the standard VHF-FM band
+C5=85250000
+C6=168250000
+C7=176250000
+C8=184250000
+C9=192250000
+C10=200250000
+C11=208250000
+C12=216250000
+; Compatible for OIRT countries that have moved from SECAM-D/K to PAL-D/K
+R1=49750000
+R2=59250000
+R3=77250000
+; Channels 4 and 5 overlap with the standard VHF-FM band
+R4=85250000
+R5=93250000
+R6=175250000
+R7=183250000
+R8=191250000
+R9=199250000
+R10=207250000
+R11=215250000
+R12=223250000
 
 [bsb_if]
 ; Based on information provided by fsphil at https://www.sanslogic.co.uk/dmac/bsb.html

--- a/src/com/steeviebops/resources/fsphil/Modes.ini
+++ b/src/com/steeviebops/resources/fsphil/Modes.ini
@@ -20,7 +20,7 @@
 FileVersion=3.2
 
 [videomodes]
-pal=i, g, pal-fm, pal-m, pal, 525pal
+pal=i, g, pal-d, pal-fm, pal-m, pal, 525pal
 ntsc=m, ntsc-fm, ntsc-bs, apollo-fsc-fm, m-cbs405, ntsc, cbs405
 secam=l, d, secam-fm, secam-i, secam
 other=a, e, 240-am, 30-am, apollo-fm, nbtv-am, 405-i, 405, 819, 240, 30, apollo, nbtv
@@ -93,21 +93,21 @@ vhf=vhf_eu
 
 [pal-d]
 alt=pal-k
-name=PAL-D/K (625 lines, 25 fps, 6.5 MHz FM audio)
+name=PAL-D/K (625 lines, 25 fps/50 Hz, 6.5 MHz FM audio)
 lines=625
 modulation=vsb
 sr=16000000
 colour=1
 audio=1
-nicam=0
-a2stereo=0
+nicam=1
+a2stereo=1
 teletext=1
 wss=1
 vits=1
 acp=1
 scrambling=1
-uhf=0
-vhf=0
+uhf=uhf_eu
+vhf=vhf_cn
 
 [pal-fm]
 name=PAL-FM (625 lines, 25 fps/50 Hz, 6.5 MHz FM audio)
@@ -666,6 +666,36 @@ F9=190300000
 F10=199700000
 F11=203450000
 F12=212850000
+
+[vhf_cn]
+region=China
+C1=49750000
+C2=57750000
+C3=65750000
+C4=77250000
+; Channels 5 overlap with the standard VHF-FM band
+C5=85250000
+C6=168250000
+C7=176250000
+C8=184250000
+C9=192250000
+C10=200250000
+C11=208250000
+C12=216250000
+; Compatible for OIRT countries that have moved from SECAM-D/K to PAL-D/K
+R1=49750000
+R2=59250000
+R3=77250000
+; Channels 4 and 5 overlap with the standard VHF-FM band
+R4=85250000
+R5=93250000
+R6=175250000
+R7=183250000
+R8=191250000
+R9=199250000
+R10=207250000
+R11=215250000
+R12=223250000
 
 [bsb_if]
 ; Based on information provided by fsphil at https://www.sanslogic.co.uk/dmac/bsb.html


### PR DESCRIPTION
Add freq list for China, and enable NICAM and A2 Stereo for PAL-D/K.

NICAM in PAL-D was introduced to China in the late 1990s and has since been integrated into most high-end TVs. 
For example, in the [source code of amlogic](https://github.com/LibreELEC/linux-amlogic/blob/amlogic-3.14.y/drivers/amlogic/dvb_tv/amlatvdemod/atvauddemod_func.c#L629-L649)

In addition, an earlier Chinese national standard (GB/T 9308-1988) used A2 Stereo with a 6.742 MHz carrier (A2-DK2). 
<details>
<img src="https://user-images.githubusercontent.com/71120049/196588306-1401faaf-ff3d-441d-a6cd-bae5722597b4.png"></img>
</details>

btw OIRT countries moved to PAL-D/K may use A2 Stereo with a 6.258 MHz carrier (A2-DK1)(but hasn't been implemented in the hacktv).